### PR TITLE
Add PURE/RICH build profiles with rich-profile packages and packaging metadata

### DIFF
--- a/.github/workflows/QCA-ALL.yml
+++ b/.github/workflows/QCA-ALL.yml
@@ -34,6 +34,7 @@ jobs:
       matrix:
         #CONFIG: [IPQ60XX-WIFI-YES, IPQ60XX-WIFI-NO, IPQ807X-WIFI-YES, IPQ807X-WIFI-NO]
         CONFIG: [IPQ60XX-WIFI-YES]
+        PROFILE: [PURE, RICH]
         SOURCE: [ones20250/immortalwrt_ipq]
         BRANCH: [main]
 
@@ -63,5 +64,7 @@ jobs:
       WRT_SOURCE: ${{matrix.SOURCE}}
       #插件调整
       WRT_PACKAGE: ${{inputs.PACKAGE}}
+      #固件版本：PURE=纯净版，RICH=丰富版
+      WRT_PROFILE: ${{matrix.PROFILE}}
       #仅输出配置文件
       WRT_TEST: ${{inputs.TEST}}

--- a/.github/workflows/WRT-CORE.yml
+++ b/.github/workflows/WRT-CORE.yml
@@ -37,6 +37,10 @@ on:
       WRT_PACKAGE:
         required: false
         type: string
+      WRT_PROFILE:
+        required: false
+        type: string
+        default: PURE
       WRT_TEST:
         required: false
         type: string
@@ -54,6 +58,8 @@ env:
   WRT_BRANCH: ${{inputs.WRT_BRANCH}}
   WRT_SOURCE: ${{inputs.WRT_SOURCE}}
   WRT_PACKAGE: ${{inputs.WRT_PACKAGE}}
+  WRT_PROFILE: ${{inputs.WRT_PROFILE}}
+  WRT_PKG_INFO: none
   WRT_TEST: ${{inputs.WRT_TEST}}
 
 jobs:
@@ -62,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Projects
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
 
       - name: Initialization Environment
         env:
@@ -87,9 +93,16 @@ jobs:
         run: |
           echo "WRT_DATE=$(TZ=UTC-8 date +"%y.%m.%d-%H.%M.%S")" >> $GITHUB_ENV
           echo "WRT_MARK=${GITHUB_REPOSITORY%%/*}" >> $GITHUB_ENV
+          WRT_PROFILE_UPPER=$(echo "${WRT_PROFILE:-PURE}" | tr '[:lower:]' '[:upper:]')
+          case "$WRT_PROFILE_UPPER" in
+            PURE|RICH) ;;
+            *) echo "Unsupported WRT_PROFILE: $WRT_PROFILE" >&2; exit 1 ;;
+          esac
+          echo "WRT_PROFILE=$WRT_PROFILE_UPPER" >> $GITHUB_ENV
           echo "WRT_INFO=${WRT_SOURCE%%/*}" >> $GITHUB_ENV
           echo "WRT_TARGET=$(grep -m 1 -oP '^CONFIG_TARGET_\K[\w]+(?=\=y)' ./Config/$WRT_CONFIG.txt)" >> $GITHUB_ENV
           echo "WRT_WIFI=wifi-yes" >> $GITHUB_ENV
+          echo "WRT_EXTRA_CONFIG=$([[ -f ./Config/GENERAL_AX6600_${WRT_PROFILE_UPPER}.txt ]] && echo ./Config/GENERAL_AX6600_${WRT_PROFILE_UPPER}.txt || true)" >> $GITHUB_ENV
           echo "WRT_KVER=none" >> $GITHUB_ENV
           echo "WRT_LIST=none" >> $GITHUB_ENV
 
@@ -105,6 +118,15 @@ jobs:
             sed -i '/.cn\//d; /tencent/d; /aliyun/d' "$PROJECT_MIRRORS_FILE"
           fi
 
+          # 丰富版补充 PassWall feeds，避免只生成依赖包但 LuCI 插件未进入最终固件。
+          if [[ "$WRT_PROFILE" == "RICH" ]]; then
+            {
+              echo "src-git passwall_packages https://github.com/Openwrt-Passwall/openwrt-passwall-packages"
+              echo "src-git passwall_luci https://github.com/Openwrt-Passwall/openwrt-passwall"
+              echo "src-git passwall2_luci https://github.com/Openwrt-Passwall/openwrt-passwall2"
+            } >> feeds.conf.default
+          fi
+
       - name: Check Scripts
         run: |
           find ./ -maxdepth 3 -type f -iregex ".*\(txt\|sh\)$" -exec dos2unix {} \; -exec chmod +x {} \;
@@ -112,10 +134,10 @@ jobs:
       - name: Check Caches
         id: check-cache
         if: env.WRT_TEST != 'true'
-        uses: actions/cache@main
+        uses: actions/cache@v4
         with:
-          key: ${{env.WRT_CONFIG}}-${{env.WRT_INFO}}-${{env.WRT_HASH}}
-          restore-keys: ${{env.WRT_CONFIG}}-${{env.WRT_INFO}}
+          key: ${{env.WRT_CONFIG}}-${{env.WRT_PROFILE}}-${{env.WRT_INFO}}-${{env.WRT_HASH}}
+          restore-keys: ${{env.WRT_CONFIG}}-${{env.WRT_PROFILE}}-${{env.WRT_INFO}}
           path: |
             ./wrt/.ccache
             ./wrt/staging_dir/host*
@@ -137,7 +159,7 @@ jobs:
           fi
 
           if ${{steps.check-cache.outputs.cache-hit != 'true'}}; then
-            CACHE_LIST=$(gh cache list --key "$WRT_CONFIG-$WRT_INFO" | cut -f 1)
+            CACHE_LIST=$(gh cache list --key "$WRT_CONFIG-$WRT_PROFILE-$WRT_INFO" | cut -f 1)
             for CACHE_KEY in $CACHE_LIST; do
               gh cache delete $CACHE_KEY
             done
@@ -159,7 +181,15 @@ jobs:
         run: |
           cd ./wrt/package/
 
+          : > "$GITHUB_WORKSPACE/package-versions.txt"
           $GITHUB_WORKSPACE/Scripts/Packages.sh
+          if [ -s "$GITHUB_WORKSPACE/package-versions.txt" ]; then
+            {
+              echo 'WRT_PKG_INFO<<EOF'
+              cat "$GITHUB_WORKSPACE/package-versions.txt"
+              echo 'EOF'
+            } >> "$GITHUB_ENV"
+          fi
           #$GITHUB_WORKSPACE/Scripts/Handles.sh
 
       - name: Custom Settings
@@ -170,7 +200,7 @@ jobs:
             cat $GITHUB_WORKSPACE/Config/$WRT_CONFIG.txt >> .config
           else
             #cat $GITHUB_WORKSPACE/Config/$WRT_CONFIG.txt $GITHUB_WORKSPACE/Config/GENERAL.txt >> .config
-            cat $GITHUB_WORKSPACE/Config/$WRT_CONFIG.txt $GITHUB_WORKSPACE/Config/GENERAL_AX6600.txt >> .config
+            cat $GITHUB_WORKSPACE/Config/$WRT_CONFIG.txt $GITHUB_WORKSPACE/Config/GENERAL_AX6600.txt ${WRT_EXTRA_CONFIG:+$GITHUB_WORKSPACE/${WRT_EXTRA_CONFIG#./}} >> .config
           fi
 
           $GITHUB_WORKSPACE/Scripts/Settings.sh
@@ -207,7 +237,10 @@ jobs:
         run: |
           cd ./wrt/ && mkdir -p ./upload/
 
-          cp -f ./.config ./upload/Config-"$WRT_CONFIG"-"$WRT_INFO"-"$WRT_BRANCH"-"$WRT_DATE".txt
+          cp -f ./.config ./upload/Config-"$WRT_CONFIG"-"$WRT_PROFILE"-"$WRT_INFO"-"$WRT_BRANCH"-"$WRT_DATE".txt
+          if [ -s "$GITHUB_WORKSPACE/package-versions.txt" ]; then
+            cp -f "$GITHUB_WORKSPACE/package-versions.txt" ./upload/Packages-"$WRT_CONFIG"-"$WRT_PROFILE"-"$WRT_INFO"-"$WRT_BRANCH"-"$WRT_DATE".txt
+          fi
 
           if [[ $WRT_TEST != 'true' ]]; then
             echo "WRT_KVER=$(find ./bin/targets/ -type f -name "*.manifest" -exec grep -oP '^kernel - \K[\d\.]+' {} \;)" >> $GITHUB_ENV
@@ -218,7 +251,7 @@ jobs:
             for FILE in $(find ./bin/targets/ -type f -iname "*$WRT_TARGET*") ; do
               EXT=$(basename $FILE | cut -d '.' -f 2-)
               NAME=$(basename $FILE | cut -d '.' -f 1 | grep -io "\($WRT_TARGET\).*")
-              NEW_FILE="$WRT_INFO"-"$WRT_BRANCH"-"$WRT_WIFI"-"$NAME"-"$WRT_DATE"."$EXT"
+              NEW_FILE="$WRT_INFO"-"$WRT_BRANCH"-"${WRT_PROFILE,,}"-"$WRT_WIFI"-"$NAME"-"$WRT_DATE"."$EXT"
               mv -f $FILE ./upload/$NEW_FILE
             done
 
@@ -235,6 +268,7 @@ jobs:
             echo "- Source: \`$WRT_SOURCE\`"
             echo "- Branch: \`$WRT_BRANCH\`"
             echo "- Config: \`$WRT_CONFIG\`"
+            echo "- Profile: \`$WRT_PROFILE\`"
             echo "- Target: \`$WRT_TARGET\`"
             echo "- Firmware mode: \`$WRT_WIFI\`"
             echo "- Build time: \`$WRT_DATE\`"
@@ -242,9 +276,9 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Release Firmware
-        uses: softprops/action-gh-release@master
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ env.WRT_CONFIG }}-${{ env.WRT_INFO }}-${{ env.WRT_BRANCH }}-${{ env.WRT_DATE }}
+          tag_name: ${{ env.WRT_CONFIG }}-${{ env.WRT_PROFILE }}-${{ env.WRT_INFO }}-${{ env.WRT_BRANCH }}-${{ env.WRT_DATE }}
           files: ./wrt/upload/*.*
           body: |
             📦 OpenWrt 自动编译固件（AX6600 / IPQ6010）
@@ -253,8 +287,13 @@ jobs:
             📌 基本信息
             源码仓库：${{ env.WRT_REPO }}
             编译分支：${{ env.WRT_BRANCH }}
+            固件版本：${{ env.WRT_PROFILE }}
             提交版本：${{ env.WRT_HASH }}
             编译时间：${{ env.WRT_DATE }}
+            ━━━━━━━━━━━━━━━━━━━━━━━
+
+            📌 外部插件来源
+            ${{ env.WRT_PKG_INFO }}
             ━━━━━━━━━━━━━━━━━━━━━━━
 
             🧩 设备与平台

--- a/.github/workflows/WRT-TEST.yml
+++ b/.github/workflows/WRT-TEST.yml
@@ -37,6 +37,14 @@ on:
       PACKAGE:
         required: false
         type: string
+      PROFILE:
+        description: '固件版本：PURE=纯净版，RICH=丰富版。'
+        default: 'PURE'
+        required: true
+        type: choice
+        options:
+          - PURE
+          - RICH
       TEST:
         description: '仅输出配置文件，不编译固件。'
         default: 'true'
@@ -75,5 +83,7 @@ jobs:
       WRT_SOURCE: ${{inputs.SOURCE}}
       #插件调整
       WRT_PACKAGE: ${{inputs.PACKAGE}}
+      #固件版本
+      WRT_PROFILE: ${{inputs.PROFILE}}
       #仅输出配置文件
       WRT_TEST: ${{inputs.TEST}}

--- a/Config/GENERAL_AX6600_RICH.txt
+++ b/Config/GENERAL_AX6600_RICH.txt
@@ -1,0 +1,63 @@
+# 丰富版插件配置：在纯净版基础上增加常用服务
+# 注意：本文件会在 GENERAL_AX6600.txt 之后追加，必要时覆盖纯净版的 n 选项。
+
+# Docker / 容器
+CONFIG_PACKAGE_luci-app-docker=y
+CONFIG_PACKAGE_luci-app-dockerman=y
+CONFIG_PACKAGE_dockerd=y
+CONFIG_PACKAGE_docker=y
+CONFIG_PACKAGE_docker-compose=y
+CONFIG_PACKAGE_luci-lib-docker=y
+CONFIG_PACKAGE_cgroupfs-mount=y
+CONFIG_PACKAGE_tini=y
+CONFIG_PACKAGE_kmod-veth=y
+CONFIG_PACKAGE_kmod-ikconfig=y
+CONFIG_PACKAGE_kmod-nf-ipvs=y
+CONFIG_PACKAGE_kmod-nf-nat=y
+CONFIG_PACKAGE_kmod-nf-nat6=y
+CONFIG_PACKAGE_kmod-nft-nat=y
+CONFIG_PACKAGE_kmod-nft-offload=y
+CONFIG_PACKAGE_kmod-nft-compat=y
+CONFIG_PACKAGE_kmod-nft-fullcone=y
+
+# PassWall / PassWall2
+CONFIG_PACKAGE_luci-app-passwall=y
+CONFIG_PACKAGE_luci-app-passwall_Iptables_Transparent_Proxy=n
+CONFIG_PACKAGE_luci-app-passwall_Nftables_Transparent_Proxy=y
+CONFIG_PACKAGE_luci-app-passwall_INCLUDE_Geoview=y
+CONFIG_PACKAGE_luci-app-passwall_INCLUDE_Haproxy=y
+CONFIG_PACKAGE_luci-app-passwall_INCLUDE_NaiveProxy=y
+CONFIG_PACKAGE_luci-app-passwall_INCLUDE_Shadowsocks_Rust_Client=y
+CONFIG_PACKAGE_luci-app-passwall_INCLUDE_Shadowsocks_Libev_Client=y
+CONFIG_PACKAGE_luci-app-passwall_INCLUDE_ShadowsocksR_Libev_Client=y
+CONFIG_PACKAGE_luci-app-passwall_INCLUDE_Simple_Obfs=y
+CONFIG_PACKAGE_luci-app-passwall_INCLUDE_SingBox=y
+CONFIG_PACKAGE_luci-app-passwall_INCLUDE_V2ray_Geodata=y
+CONFIG_PACKAGE_luci-app-passwall_INCLUDE_V2ray_Plugin=y
+CONFIG_PACKAGE_luci-app-passwall_INCLUDE_Xray=y
+CONFIG_PACKAGE_luci-app-passwall_INCLUDE_Xray_Plugin=y
+CONFIG_PACKAGE_luci-app-passwall_INCLUDE_Trojan_Plus=y
+CONFIG_PACKAGE_luci-app-passwall2=y
+CONFIG_PACKAGE_luci-app-passwall2_Basic_Core_All=y
+CONFIG_PACKAGE_luci-app-passwall2_Iptables_Transparent_Proxy=n
+CONFIG_PACKAGE_luci-app-passwall2_Nftables_Transparent_Proxy=y
+CONFIG_PACKAGE_luci-app-passwall2_INCLUDE_Haproxy=y
+CONFIG_PACKAGE_luci-app-passwall2_INCLUDE_NaiveProxy=y
+CONFIG_PACKAGE_luci-app-passwall2_INCLUDE_Xray=y
+CONFIG_PACKAGE_luci-app-passwall2_INCLUDE_Xray_Plugin=y
+CONFIG_PACKAGE_luci-app-passwall2_INCLUDE_Shadowsocks_Rust_Client=y
+CONFIG_PACKAGE_luci-app-passwall2_INCLUDE_Shadowsocks_Libev_Client=y
+CONFIG_PACKAGE_luci-app-passwall2_INCLUDE_ShadowsocksR_Libev_Client=y
+CONFIG_PACKAGE_luci-app-passwall2_INCLUDE_Simple_Obfs=y
+CONFIG_PACKAGE_luci-app-passwall2_INCLUDE_V2ray_Plugin=y
+CONFIG_PACKAGE_luci-app-passwall2_INCLUDE_Trojan_Plus=y
+
+# OpenClash
+CONFIG_PACKAGE_luci-app-openclash=y
+CONFIG_PACKAGE_luci-compat=y
+CONFIG_PACKAGE_dnsmasq_full_nftset=y
+CONFIG_PACKAGE_dnsmasq_full_ipset=n
+
+# AdGuard Home
+CONFIG_PACKAGE_luci-app-adguardhome=y
+CONFIG_PACKAGE_adguardhome=y

--- a/README.md
+++ b/README.md
@@ -66,12 +66,32 @@ OpenWrt / AX6600 / IPQ6010 / JDCloud RE-CS-02 / NSS / Router Firmware / Cloud Bu
 | 说明 | 详情 |
 |------|------|
 | **编译时间** | 显示的时间为编译开始时间，用于对应上游源码版本 |
-| **基础功能** | 默认包含完整网络功能栈 |
-| **扩展插件** | 可通过自定义配置 `.config` 文件增加额外插件 |
+| **版本划分** | 默认同时构建 `PURE` 纯净版与 `RICH` 丰富版 |
+| **基础功能** | 纯净版保持当前轻量配置，包含完整网络功能栈 |
+| **扩展插件** | 丰富版额外集成 Docker / Dockerman、PassWall / PassWall2、OpenClash、AdGuard Home 等常用组件，也可通过自定义配置 `.config` 文件继续增加插件 |
 | **硬件平台** | 基于 QUALCOMMAX（IPQ6010）架构 |
 | **性能优化** | 针对 IPQ6010 平台进行网络性能调优 |
 
 ---
+
+
+### 固件版本
+
+| 版本 | 适合人群 | 预置内容 |
+|------|----------|----------|
+| `PURE` 纯净版 | 希望系统轻量、稳定，按需自行安装插件的用户 | 保持当前配置，预装基础网络与常用管理插件 |
+| `RICH` 丰富版 | 希望刷完即用常见扩展服务的用户 | 在纯净版基础上增加 Docker / Dockerman、PassWall / PassWall2、OpenClash、AdGuard Home |
+
+> 💡 Releases 中的文件名会包含 `pure` 或 `rich`，请按需求下载对应版本。
+
+### 版本与验证建议
+
+- `PURE`：推荐作为日常稳定版，保持当前轻量配置。
+- `RICH`：丰富版会额外集成 Docker / Dockerman、PassWall / PassWall2、OpenClash、AdGuard Home，固件体积和运行资源占用都会明显高于纯净版。
+- 手动测试时可在 `WRT-TEST` 工作流选择 `PROFILE=PURE` 或 `PROFILE=RICH`；建议丰富版发布前至少先用 `TEST=true` 生成最终 `.config`，再用完整编译确认上游插件依赖没有变化。
+- Release 会额外上传 `Packages-*.txt` 记录丰富版外部插件仓库、分支和 commit，方便排查 OpenClash / PassWall / PassWall2 上游变更导致的编译问题。丰富版还会额外加入 PassWall/PassWall2 feeds，并显式拉取 `luci-app-passwall` 与 `luci-app-passwall2`，避免出现“编译成功但系统里没有插件入口”的情况。
+
+> ⚠️ 丰富版依赖外部插件仓库和上游 feeds，若上游调整包名或依赖，可能需要同步更新 `Config/GENERAL_AX6600_RICH.txt`。
 
 ## 📂 项目结构
 

--- a/Scripts/Packages.sh
+++ b/Scripts/Packages.sh
@@ -32,6 +32,12 @@ UPDATE_PACKAGE() {
 	# 克隆 GitHub 仓库
 	git clone --depth=1 --single-branch --branch "$PKG_BRANCH" "https://github.com/$PKG_REPO.git"
 
+	local PKG_COMMIT
+	PKG_COMMIT=$(git -C "$REPO_NAME" rev-parse --short HEAD 2>/dev/null || echo unknown)
+	if [ -n "$GITHUB_WORKSPACE" ]; then
+		echo "$PKG_NAME $PKG_REPO $PKG_BRANCH $PKG_COMMIT" >> "$GITHUB_WORKSPACE/package-versions.txt"
+	fi
+
 	# 处理克隆的仓库
 	if [[ "$PKG_SPECIAL" == "pkg" ]]; then
 		find "./$REPO_NAME"/*/ -maxdepth 3 -type d -iname "*$PKG_NAME*" -prune -exec cp -rf {} ./ \;
@@ -55,9 +61,14 @@ UPDATE_PACKAGE() {
 #UPDATE_PACKAGE "homeproxy" "ones20250/homeproxy" "master"
 #UPDATE_PACKAGE "momo" "nikkinikki-org/OpenWrt-momo" "main"
 #UPDATE_PACKAGE "nikki" "nikkinikki-org/OpenWrt-nikki" "main"
-#UPDATE_PACKAGE "openclash" "vernesong/OpenClash" "master" "pkg"
-#UPDATE_PACKAGE "passwall" "Openwrt-Passwall/openwrt-passwall" "main" "pkg"
-#UPDATE_PACKAGE "passwall2" "Openwrt-Passwall/openwrt-passwall2" "main" "pkg"
+if [[ "${WRT_PROFILE^^}" == "RICH" ]]; then
+	UPDATE_PACKAGE "openclash" "vernesong/OpenClash" "master" "pkg"
+	UPDATE_PACKAGE "passwall" "Openwrt-Passwall/openwrt-passwall" "main" "pkg"
+	UPDATE_PACKAGE "passwall2" "Openwrt-Passwall/openwrt-passwall2" "main" "pkg"
+	# 明确拉取 LuCI 目录，避免只拉到依赖包导致固件内没有管理界面入口。
+	UPDATE_PACKAGE "luci-app-passwall" "Openwrt-Passwall/openwrt-passwall" "main" "pkg"
+	UPDATE_PACKAGE "luci-app-passwall2" "Openwrt-Passwall/openwrt-passwall2" "main" "pkg"
+fi
 
 #UPDATE_PACKAGE "mosdns" "sbwml/luci-app-mosdns" "v5" "" "v2dat"
 


### PR DESCRIPTION
### Motivation
- Introduce a profile concept to produce two firmware flavors (`PURE` and `RICH`) so users can choose a minimal or feature-rich build.  
- Ensure the rich flavor pulls additional feeds/packages and records external package sources/versions to avoid missing LuCI entries and aid troubleshooting.

### Description
- Added a `WRT_PROFILE` input to `WRT-CORE.yml`, `WRT-TEST.yml`, and the `QCA-ALL` workflow, defaulting to `PURE`, and validate/upper-case the profile early in the core workflow.  
- Implemented profile-aware logic: include an extra config file `Config/GENERAL_AX6600_RICH.txt` when `RICH`, append PassWall feeds for the rich profile, and append the extra config into `.config via `WRT_EXTRA_CONFIG`.  
- Made build/cache and release outputs profile-aware by adding `WRT_PROFILE` to cache keys, `gh cache` cleanup key, upload filenames, and release `tag_name` and release body; upgraded action refs (`actions/checkout@v4`, `actions/cache@v4`, `softprops/action-gh-release@v2`).  
- Track external package clones and versions by writing `package-versions.txt` in `Scripts/Packages.sh` and exporting its contents into `WRT_PKG_INFO` for the release body, and conditionally clone/update PassWall/OpenClash/LuCI packages only when `WRT_PROFILE` is `RICH`.

### Testing
- No additional automated tests were added or executed as part of this change; CI workflow files were updated to be profile-aware and should be exercised by the existing GitHub Actions runs when triggering `WRT-TEST` or `QCA-ALL` workflows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a478dee3524832ab63bc11fbe1ed6db)